### PR TITLE
Adding functionality to ignore mocha timing statements

### DIFF
--- a/mocha-list-tests.js
+++ b/mocha-list-tests.js
@@ -140,6 +140,16 @@ function captureItFunctions (testName, ignoreFunction) {
 }
 
 // -----------------------------------------------------------------------------
+// captureTimingFunctions
+//
+// Helper function to captures all of mocha's timing calls and ignores the
+// functionality
+// -----------------------------------------------------------------------------
+function captureTimingFunctions (timing, ignoreFunction) {
+  timing = null;
+}
+
+// -----------------------------------------------------------------------------
 // findSuitesAndTests
 //
 // Find all suites and tests in given folder
@@ -160,8 +170,12 @@ function findSuitesAndTests (testFolder, extensions) {
   let allTestFiles = lookupFiles (testFolder, extensions || ['js'], true);
 
   // HOOK: describe/it function hooks
-  global.describe = captureDescribeFunctions
-  global.it       = captureItFunctions
+  global.describe   = captureDescribeFunctions
+  global.it         = captureItFunctions
+  global.before     = captureTimingFunctions
+  global.beforeEach = captureTimingFunctions
+  global.after      = captureTimingFunctions
+  global.afterEach  = captureTimingFunctions
 
   // capture all suites and direct tests
   for (let i = 0; i < allTestFiles.length; i++) {


### PR DESCRIPTION
    describe('Mocha Timings Test', function() {
      before(function() {
        console.log('this log is done before the test is ran')
      })
      it('should run a test in usingMochaTimings', function() {
        assert.equal(2, 1 + 1);
      })

In cases like this you'll get a TypeError: before is not a function issue. The fix will just ignore each of mocha's timings.